### PR TITLE
Fix international GameDataDirectoryFinder for StarRailGacha

### DIFF
--- a/src-tauri/src/gacha/impl_starrail.rs
+++ b/src-tauri/src/gacha/impl_starrail.rs
@@ -39,7 +39,7 @@ impl GameDataDirectoryFinder for StarRailGacha {
     let mut directories = Vec::new();
 
     // TODO: Untested
-    const INTERNATIONAL_PLAYER_LOG : &str = "/Star Rail/Player.log";
+    const INTERNATIONAL_PLAYER_LOG : &str = "Star Rail/Player.log";
     const INTERNATIONAL_DIR_KEYWORD: &str = "/StarRail_Data/";
 
     let mut player_log = cognosphere_dir.join(INTERNATIONAL_PLAYER_LOG);


### PR DESCRIPTION
With `/Star Rail/Player.log`, `.join()` treats it as an absolute path, which causes it to fail. Changing it to `Star Rail/Player.log` will make `.join()` treat it as a relative path, which is what we want.

I've tested this on my computer and it's able to discover my game data directory with the change. 