### PR TITLE
fix: ZZZ global version data folder & Gacha Log URL

### DIFF
--- a/src-tauri/src/business/data_folder_locator.rs
+++ b/src-tauri/src/business/data_folder_locator.rs
@@ -75,7 +75,7 @@ impl DataFolderLocator for UnityLogDataFolderLocator {
       "Player.log"
     };
 
-    let appdata_folder = if biz.business == Business::GenshinImpact || biz.is_official() {
+    let appdata_folder = if biz.business == Business::GenshinImpact || biz.business == Business::ZenlessZoneZero || biz.is_official() {
       &*consts::PLATFORM.appdata_locallow_mihoyo
     } else {
       &*consts::PLATFORM.appdata_locallow_cognosphere

--- a/src-tauri/src/models/business.rs
+++ b/src-tauri/src/models/business.rs
@@ -139,7 +139,7 @@ pub const BIZ_ZENLESS_ZONE_ZERO_GLOBAL: BizInternals = biz!(
   "ZenlessZoneZero",
   "ZenlessZoneZero",
   "ZenlessZoneZero_Data",
-  "https://public-operation-nap-sg.mihoyo.com/common/gacha_record/api/getGachaLog",
+  "https://public-operation-nap-sg.hoyoverse.com/common/gacha_record/api/getGachaLog",
 );
 
 static BIZ_INTERNALS: LazyLock<HashMap<(Business, BusinessRegion), &'static BizInternals>> =

--- a/src-tauri/src/models/business.rs
+++ b/src-tauri/src/models/business.rs
@@ -136,7 +136,7 @@ pub const BIZ_ZENLESS_ZONE_ZERO_GLOBAL: BizInternals = biz!(
   ZenlessZoneZero,
   Global,
   "nap_global",
-  "Zenless Zone Zero",
+  "ZenlessZoneZero",
   "ZenlessZoneZero",
   "ZenlessZoneZero_Data",
   "https://public-operation-nap-sg.mihoyo.com/common/gacha_record/api/getGachaLog",


### PR DESCRIPTION
- 修复ZZZ国际服的数据本地目录
- 修复ZZZ国际服 GachaLog URL

**修复前：**
<img width="450" height="359" alt="image" src="https://github.com/user-attachments/assets/826d4689-1fc3-440d-99b7-aa961ae53ca4" />
<img width="380" height="136" alt="image" src="https://github.com/user-attachments/assets/a5156e02-4a19-4774-a46f-8369488e5b91" />

**修复后：**
<img width="703" height="117" alt="image" src="https://github.com/user-attachments/assets/116ce9a7-56ab-42ec-a003-1e6cb800f37d" />
